### PR TITLE
ci: 👷 python installation tests on apple silicon runner for make sure all packages installable

### DIFF
--- a/.github/workflows/install-tests.yml
+++ b/.github/workflows/install-tests.yml
@@ -1,0 +1,28 @@
+name: 🚀 Install and Test Python Versions 🐍
+on: [pull_request, workflow_dispatch]
+jobs:
+  ci:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["macos-14"]
+        python-version: ["3.10", "3.11", "3.12"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: 🛎️ Checkout repository
+        uses: actions/checkout@v4
+
+      - name: 🐍 Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+
+      - name: 📦 Create virtual environment
+        run: python3 -m venv .venv
+
+      - name: 🏗️ Activate virtual environment
+        run: source .venv/bin/activate
+
+      - name: ⚙️ Install packages
+        run: pip install -e .


### PR DESCRIPTION
Initial CI added but run 'chat-with-mlx' using too much RAM (It needs more than 8GB because of initial run/download)  needs to be minimized to at least run basic commands like "--version" to see imports are fine in the project. I hope that will clear up certain errors such as "no mlx available" I did not add python3.8 and 3.9 initially yet because in https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json it does not exist arm64 version I will create another CI to handle that part to test minimal version as well. 