### PR TITLE
feat(cli): ✨ port and share params added

### DIFF
--- a/chat_with_mlx/app.py
+++ b/chat_with_mlx/app.py
@@ -327,11 +327,13 @@ with gr.Blocks(fill_height=True, theme=gr.themes.Soft()) as demo:
                     stop_index_button.click(kill_index, outputs=[index_status])
 
 
+def app(port, share):
+    print(f"Starting MLX Chat on port {port}")
+    print(f"Sharing: {share}")
+    demo.launch(inbrowser=True, share=share, server_port=port)
+
+
 def main():
-    demo.launch(inbrowser=True)
-
-
-if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Chat with MLX \n"
         "Native RAG on MacOS and Apple Silicon with MLX 🧑‍💻"
@@ -339,4 +341,16 @@ if __name__ == "__main__":
     parser.add_argument(
         "--version", action="version", version=f"Chat with MLX {__version__}"
     )
-    main()
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=7860,
+        help="Port number to run the app",
+    )
+    parser.add_argument(
+        "--share",
+        default=False,
+        help="Enable sharing the app",
+    )
+    args = parser.parse_args()
+    app(port=args.port, share=args.share)


### PR DESCRIPTION
@qnguyen3  port and share added.

Fix: https://github.com/qnguyen3/chat-with-mlx/issues/21
Fix: https://github.com/qnguyen3/chat-with-mlx/issues/13

```console
chat-with-mlx --port 9000 --share True
<All keys matched successfully>
Namespace(port=9000, share='True')
Starting MLX Chat on port 9000
Sharing: True
Running on local URL:  http://127.0.0.1:9000
Running on public URL: https://XXXXXXX.gradio.live

This share link expires in 72 hours. For free permanent hosting and GPU upgrades, run `gradio deploy` from Terminal to deploy to Spaces (https://huggingface.co/spaces)
```

----

```console
chat-with-mlx
<All keys matched successfully>
Namespace(port=7860, share=False)
Starting MLX Chat on port 7860
Sharing: False
Running on local URL:  http://127.0.0.1:7860

To create a public link, set `share=True` in `launch()`.
^CKeyboard interruption in main thread... closing server.
```

---- 

```console
chat-with-mlx --help
<All keys matched successfully>
usage: chat-with-mlx [-h] [--version] [--port PORT] [--share SHARE]

Chat with MLX Native RAG on MacOS and Apple Silicon with MLX 🧑‍💻

options:
  -h, --help     show this help message and exit
  --version      show program's version number and exit
  --port PORT    Port number to run the app
  --share SHARE  Enable sharing the app
```
